### PR TITLE
Add support for NMT startup options

### DIFF
--- a/canopen/sphinx/user-guide/configuration.rst
+++ b/canopen/sphinx/user-guide/configuration.rst
@@ -107,8 +107,8 @@ but come from the lely core library. Below you find a list of possible configura
   error_behavior;	A dictionary of error behaviors for different classes or errors (default: {1: 0x00}, see object 1029).
   nmt_inhibit_time;	The NMT inhibit time in multiples of 100 μs (default: 0, see object 102A).
   start;	Specifies whether the master shall switch into the NMT operational state by itself (default: true, see bit 2 in object 1F80).
-  start_nodes;	Specifies whether the master shall start the slaves (default: true, see bit 3 in object 1F80).
-  start_all_nodes;	Specifies whether the master shall start all nodes simultaneously (default: false, see bit 1 in object 1F80).
+  start_nodes;  Specifies whether the master shall start the slaves. When enabled each device receives an NMT reset (``RESET_COMM`` or ``RESET_NODE`` depending on ``reset_communication``) followed by ``START`` (default: true, see bit 3 in object 1F80).
+  start_all_nodes;      Specifies whether the master shall start all nodes simultaneously by sending a broadcast ``RESET_NODE`` and ``START`` (default: false, see bit 1 in object 1F80).
   reset_all_nodes;	Specifies whether all slaves shall be reset in case of an error event on a mandatory slave (default: false, see bit 4 in object 1F80).
   stop_all_nodes;	Specifies whether all slaves shall be stopped in case of an error event on a mandatory slave (default: false, see bit 6 in object 1F80).
   boot_time;	The timeout for booting mandatory slaves in ms (default: 0, see object 1F89).
@@ -149,7 +149,7 @@ device.
   tpdo;	The Transmit-PDO configuration (see below).
   boot;	Specifies whether the slave will be configured and booted by the master (default: true, see bit 2 in object 1F81).
   mandatory;	Specifies whether the slave is mandatory (default: false, see bit 3 in object 1F81).
-  reset_communication;	Specifies whether the NMT reset communication command may be sent to the slave (default: true, see bit 4 in object 1F81).
+  reset_communication;  Specifies whether the NMT reset communication command may be sent to the slave. If false the slave is reset with ``RESET_NODE`` instead (default: true, see bit 4 in object 1F81).
   software_file;	The name of the file containing the firmware (default: "", see object 1F58).
   software_version;	The expected software version (default: 0x00000000, see object 1F55).
   configuration_file;	The name of the file containing the configuration (default: "<dcf_path>/<name>.bin" (where <name> is the section name), see object 1F22).

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -303,6 +303,14 @@ void NodeCanopenBaseDriver<NODETYPE>::add_to_master()
   }
   RCLCPP_INFO(this->node_->get_logger(), "Driver booted and ready.");
 
+  if (start_node_)
+  {
+    auto cmd =
+      reset_communication_ ? canopen::NmtCommand::RESET_COMM : canopen::NmtCommand::RESET_NODE;
+    this->lely_driver_->nmt_command(cmd);
+    this->lely_driver_->nmt_command(canopen::NmtCommand::START);
+  }
+
   if (diagnostic_enabled_.load())
   {
     diagnostic_collector_->updateAll(

--- a/canopen_core/include/canopen_core/configuration_manager.hpp
+++ b/canopen_core/include/canopen_core/configuration_manager.hpp
@@ -41,6 +41,9 @@ private:
   std::string file_;                           ///< Stores the configuration file name
   YAML::Node root_;                            ///< Stores YAML root node
   std::map<std::string, YAML::Node> devices_;  ///< Stores all configuration per device
+  bool start_nodes_{true};                     ///< Master start nodes flag
+  bool start_all_nodes_{false};                ///< Master start all nodes flag
+  std::map<std::string, bool> reset_communication_;  ///< Reset communication flag per device
 
 public:
   ConfigurationManager(std::string & file) : file_(file) { root_ = YAML::LoadFile(file_.c_str()); }
@@ -105,6 +108,20 @@ public:
    * @return uint32_t         Number of devices discovered
    */
   uint32_t get_all_devices(std::vector<std::string> & devices);
+
+  bool get_start_nodes() const { return start_nodes_; }
+
+  bool get_start_all_nodes() const { return start_all_nodes_; }
+
+  bool get_reset_communication(const std::string & device) const
+  {
+    auto it = reset_communication_.find(device);
+    if (it != reset_communication_.end())
+    {
+      return it->second;
+    }
+    return true;
+  }
 };
 }  // namespace ros2_canopen
 

--- a/canopen_core/include/canopen_core/device_container.hpp
+++ b/canopen_core/include/canopen_core/device_container.hpp
@@ -201,6 +201,18 @@ public:
    */
   virtual size_t count_drivers() { return registered_drivers_.size(); }
 
+  bool get_start_nodes() const { return start_nodes_; }
+  bool get_start_all_nodes() const { return start_all_nodes_; }
+  bool get_reset_communication(uint16_t id) const
+  {
+    auto it = reset_communication_.find(id);
+    if (it != reset_communication_.end())
+    {
+      return it->second;
+    }
+    return true;
+  }
+
   /**
    * @brief Get node ids of all drivers with type
    *
@@ -281,6 +293,9 @@ protected:
   std::string dcf_bin_;             ///< Cached value of .bin file parameter
   std::string can_interface_name_;  ///< Cached value of can interface name
   bool lifecycle_operation_;
+  bool start_nodes_{true};               ///< Start nodes flag from bus config
+  bool start_all_nodes_{false};          ///< Start all nodes flag from bus config
+  std::map<uint16_t, bool> reset_communication_;  ///< Reset communication per node id
 
   // ROS Objects
   std::weak_ptr<rclcpp::Executor> executor_;  ///< Pointer to ros executor instance

--- a/canopen_core/include/canopen_core/node_interfaces/node_canopen_driver.hpp
+++ b/canopen_core/include/canopen_core/node_interfaces/node_canopen_driver.hpp
@@ -76,6 +76,8 @@ protected:
   std::string container_name_;
   std::string eds_;
   std::string bin_;
+  bool start_node_{true};
+  bool reset_communication_{true};
 
   rclcpp::CallbackGroup::SharedPtr client_cbg_;
   rclcpp::CallbackGroup::SharedPtr timer_cbg_;
@@ -142,6 +144,8 @@ public:
     node_->declare_parameter("node_id", 0);
     node_->declare_parameter("non_transmit_timeout", 100);
     node_->declare_parameter("config", "");
+    node_->declare_parameter("start_node", true);
+    node_->declare_parameter("reset_communication", true);
     this->init(true);
     this->initialised_.store(true);
     RCLCPP_DEBUG(node_->get_logger(), "init_end");
@@ -193,6 +197,8 @@ public:
     node_->get_parameter("non_transmit_timeout", non_transmit_timeout);
     node_->get_parameter("node_id", this->node_id_);
     node_->get_parameter("config", config);
+    node_->get_parameter("start_node", start_node_);
+    node_->get_parameter("reset_communication", reset_communication_);
     this->config_ = YAML::Load(config);
     this->non_transmit_timeout_ = std::chrono::milliseconds(non_transmit_timeout);
     auto path = this->config_["dcf_path"].as<std::string>();

--- a/canopen_core/src/configuration_manager.cpp
+++ b/canopen_core/src/configuration_manager.cpp
@@ -41,6 +41,26 @@ void ConfigurationManager::init_config()
     {
       config_node["dcf_path"] = dcf_path;
     }
+    if (driver_name == "master")
+    {
+      if (config_node["start_nodes"])
+      {
+        start_nodes_ = config_node["start_nodes"].as<bool>();
+      }
+      if (config_node["start_all_nodes"])
+      {
+        start_all_nodes_ = config_node["start_all_nodes"].as<bool>();
+      }
+    }
+    else
+    {
+      bool reset_comm = true;
+      if (config_node["reset_communication"])
+      {
+        reset_comm = config_node["reset_communication"].as<bool>();
+      }
+      reset_communication_[driver_name] = reset_comm;
+    }
     devices_.insert({driver_name, config_node});
   }
 }

--- a/canopen_core/src/device_container.cpp
+++ b/canopen_core/src/device_container.cpp
@@ -244,6 +244,10 @@ bool DeviceContainer::load_master()
       params.push_back(rclcpp::Parameter("node_id", (int)node_id.value()));
       params.push_back(rclcpp::Parameter("non_transmit_timeout", 100));
       params.push_back(rclcpp::Parameter("config", config_->dump_device(*it)));
+      start_nodes_ = config_->get_start_nodes();
+      start_all_nodes_ = config_->get_start_all_nodes();
+      params.push_back(rclcpp::Parameter("start_nodes", start_nodes_));
+      params.push_back(rclcpp::Parameter("start_all_nodes", start_all_nodes_));
 
       if (!this->load_component(
             package_name.value(), driver_name.value(), node_id.value(), *it, params,
@@ -320,6 +324,10 @@ bool DeviceContainer::load_drivers()
       params.push_back(rclcpp::Parameter("node_id", (int)node_id.value()));
       params.push_back(rclcpp::Parameter("config", config_->dump_device(*it)));
       params.push_back(rclcpp::Parameter("non_transmit_timeout", 100));
+      bool reset_comm = config_->get_reset_communication(*it);
+      reset_communication_[node_id.value()] = reset_comm;
+      params.push_back(rclcpp::Parameter("reset_communication", reset_comm));
+      params.push_back(rclcpp::Parameter("start_node", start_nodes_));
 
       if (!this->load_component(
             package_name.value(), driver_name.value(), node_id.value(), *it, params,

--- a/canopen_core/test/bus_configs/good_driver.yml
+++ b/canopen_core/test/bus_configs/good_driver.yml
@@ -5,3 +5,4 @@ proxy_device_1:
   dcf_path: "install/canopen_tests/share/canopen_tests/config/simple"
   driver: "ros2_canopen::CanopenDriver"
   package: "canopen_core"
+  reset_communication: true

--- a/canopen_core/test/bus_configs/good_master.yml
+++ b/canopen_core/test/bus_configs/good_master.yml
@@ -3,3 +3,5 @@ master:
   node_id: 1
   driver: "ros2_canopen::CanopenMaster"
   package: "canopen_core"
+  start_nodes: true
+  start_all_nodes: false

--- a/canopen_core/test/bus_configs/good_master_and_two_driver.yml
+++ b/canopen_core/test/bus_configs/good_master_and_two_driver.yml
@@ -3,6 +3,8 @@ master:
   node_id: 1
   driver: "ros2_canopen::CanopenMaster"
   package: "canopen_core"
+  start_nodes: true
+  start_all_nodes: false
 
 proxy_device_1:
   node_id: 2
@@ -10,6 +12,7 @@ proxy_device_1:
   dcf_path: "install/canopen_tests/share/canopen_tests/config/simple"
   driver: "ros2_canopen::CanopenDriver"
   package: "canopen_core"
+  reset_communication: true
 
 proxy_device_2:
   node_id: 3
@@ -17,3 +20,4 @@ proxy_device_2:
   dcf_path: "install/canopen_tests/share/canopen_tests/config/simple"
   driver: "ros2_canopen::CanopenDriver"
   package: "canopen_core"
+  reset_communication: true

--- a/canopen_core/test/test_device_container.cpp
+++ b/canopen_core/test/test_device_container.cpp
@@ -610,6 +610,15 @@ TEST_F(DeviceContainerTest, test_load_master_good)
         std::string & package_name, std::string & driver_name, uint16_t node_id,
         std::string & node_name, std::vector<rclcpp::Parameter> & params) -> bool
       {
+        bool have_start_nodes = false;
+        bool have_start_all = false;
+        for (auto & p : params)
+        {
+          if (p.get_name() == "start_nodes") have_start_nodes = p.as_bool();
+          if (p.get_name() == "start_all_nodes") have_start_all = p.as_bool();
+        }
+        EXPECT_TRUE(have_start_nodes);
+        EXPECT_FALSE(have_start_all);
         device_container->can_master_ =
           std::static_pointer_cast<ros2_canopen::CanopenMasterInterface>(can_master);
         return true;
@@ -679,6 +688,15 @@ TEST_F(DeviceContainerTest, test_load_driver_good)
         std::string & package_name, std::string & driver_name, uint16_t node_id,
         std::string & node_name, std::vector<rclcpp::Parameter> & params) -> bool
       {
+        bool reset_param = false;
+        bool start_param = false;
+        for (auto & p : params)
+        {
+          if (p.get_name() == "reset_communication") reset_param = p.as_bool();
+          if (p.get_name() == "start_node") start_param = p.as_bool();
+        }
+        EXPECT_TRUE(reset_param);
+        EXPECT_TRUE(start_param);
         device_container->registered_drivers_[2] =
           std::static_pointer_cast<ros2_canopen::CanopenDriverInterface>(driver);
         return true;

--- a/canopen_tests/config/simple/bus.yml
+++ b/canopen_tests/config/simple/bus.yml
@@ -5,6 +5,8 @@ master:
   node_id: 1
   driver: "ros2_canopen::MasterDriver"
   package: "canopen_master_driver"
+  start_nodes: true
+  start_all_nodes: false
 
 proxy_device_1:
   node_id: 2
@@ -13,6 +15,7 @@ proxy_device_1:
   package: "canopen_proxy_driver"
   polling: true
   period: 10
+  reset_communication: true
   namespace: "/test1"
 
 proxy_device_2:
@@ -23,3 +26,4 @@ proxy_device_2:
   polling: true
   period: 10
   namespace: "/test2"
+  reset_communication: true

--- a/canopen_tests/config/simple_lifecycle/bus.yml
+++ b/canopen_tests/config/simple_lifecycle/bus.yml
@@ -5,12 +5,15 @@ master:
   node_id: 1
   driver: "ros2_canopen::LifecycleMasterDriver"
   package: "canopen_master_driver"
+  start_nodes: true
+  start_all_nodes: false
 
 proxy_device_1:
   node_id: 2
   dcf: "simple.eds"
   driver: "ros2_canopen::LifecycleProxyDriver"
   package: "canopen_proxy_driver"
+  reset_communication: true
 
 proxy_device_2:
   node_id: 3


### PR DESCRIPTION
## Summary
- parse `start_nodes`, `start_all_nodes`, and `reset_communication` in `ConfigurationManager`
- propagate these options through `DeviceContainer`
- expose parameters in master/driver interfaces
- issue NMT reset and start commands when drivers are added
- document new parameters and show them in sample bus configurations
- extend unit tests

## Testing
- `colcon test --packages-select canopen_core` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c7b459f083248af87c24e2acd74f