### PR TITLE
Support CiA 301 device profile segments

### DIFF
--- a/canopen/sphinx/user-guide/cia402-driver.rst
+++ b/canopen/sphinx/user-guide/cia402-driver.rst
@@ -142,6 +142,9 @@ Additional parameters that can be used in bus.yml for this driver.
   * - scale_vel_from_dev
     - double
     - Scaling factor to convert from device units to SI units for velocity.
+  * - device_profile_segment
+    - int
+    - Selects the CiA 301 device profile segment (0-7). Each step shifts device profile indices by 0x800 to address multiple modules on a single node.
   * - position_mode
     - int
     - The drives operation mode to use for the position interface

--- a/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
@@ -28,6 +28,7 @@ class DefaultHomingMode : public HomingMode
 {
   const uint16_t index = 0x6098;
   std::shared_ptr<LelyDriverBridge> driver;
+  uint16_t index_offset_;
 
   std::atomic<bool> execute_;
 
@@ -51,10 +52,10 @@ class DefaultHomingMode : public HomingMode
   }
 
 public:
-  DefaultHomingMode(std::shared_ptr<LelyDriverBridge> driver, int homing_timeout_seconds)
-  : homing_timeout_seconds_(homing_timeout_seconds)
+  DefaultHomingMode(
+    std::shared_ptr<LelyDriverBridge> driver, int homing_timeout_seconds, uint16_t index_offset = 0)
+  : driver(driver), index_offset_(index_offset), homing_timeout_seconds_(homing_timeout_seconds)
   {
-    this->driver = driver;
   }
   virtual bool start();
   virtual bool read(const uint16_t & sw);

--- a/canopen_402_driver/include/canopen_402_driver/mode_forward_helper.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/mode_forward_helper.hpp
@@ -30,11 +30,12 @@ template <uint16_t ID, typename TYPE, uint16_t OBJ, uint8_t SUB, uint16_t CW_MAS
 class ModeForwardHelper : public ModeTargetHelper<TYPE>
 {
   std::shared_ptr<LelyDriverBridge> driver;
+  uint16_t index_offset_;
 
 public:
-  ModeForwardHelper(std::shared_ptr<LelyDriverBridge> driver) : ModeTargetHelper<TYPE>(ID)
+  ModeForwardHelper(std::shared_ptr<LelyDriverBridge> driver, uint16_t index_offset = 0)
+  : ModeTargetHelper<TYPE>(ID), driver(driver), index_offset_(index_offset)
   {
-    this->driver = driver;
   }
   virtual bool read(const uint16_t & sw) { return true; }
   virtual bool write(Mode::OpModeAccesser & cw)
@@ -43,7 +44,7 @@ public:
     {
       cw = cw.get() | CW_MASK;
 
-      driver->universal_set_value<TYPE>(OBJ, SUB, this->getTarget());
+      driver->universal_set_value<TYPE>(OBJ + index_offset_, SUB, this->getTarget());
       return true;
     }
     else

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -63,6 +63,7 @@ protected:
   double offset_pos_from_dev_;
   ros2_canopen::State402::InternalState switching_state_;
   int homing_timeout_seconds_;
+  uint16_t device_profile_segment_{0};
 
   void publish();
   virtual void poll_timer_callback() override;

--- a/canopen_402_driver/include/canopen_402_driver/profiled_position_mode.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/profiled_position_mode.hpp
@@ -29,6 +29,7 @@ class ProfiledPositionMode : public ModeTargetHelper<int32_t>
 {
   const uint16_t index = 0x607A;
   std::shared_ptr<LelyDriverBridge> driver;
+  uint16_t index_offset_;
 
   double last_target_;
   uint16_t sw_;
@@ -46,10 +47,10 @@ public:
     CW_Immediate = Command402::CW_Operation_mode_specific1,
     CW_Blending = Command402::CW_Operation_mode_specific3,
   };
-  ProfiledPositionMode(std::shared_ptr<LelyDriverBridge> driver)
-  : ModeTargetHelper(MotorBase::Profiled_Position)
+  ProfiledPositionMode(
+    std::shared_ptr<LelyDriverBridge> driver, uint16_t index_offset = 0)
+  : ModeTargetHelper(MotorBase::Profiled_Position), driver(driver), index_offset_(index_offset)
   {
-    this->driver = driver;
   }
 
   virtual bool start()
@@ -77,7 +78,7 @@ public:
         }
         else
         {
-          driver->universal_set_value(index, 0x0, target);
+          driver->universal_set_value(index + index_offset_, 0x0, target);
           cw.set(CW_NewPoint);
           last_target_ = target;
         }

--- a/canopen_402_driver/src/default_homing_mode.cpp
+++ b/canopen_402_driver/src/default_homing_mode.cpp
@@ -53,7 +53,7 @@ bool DefaultHomingMode::write(Mode::OpModeAccesser & cw)
 
 bool DefaultHomingMode::executeHoming()
 {
-  int hmode = driver->universal_get_value<int8_t>(index, 0x0);
+  int hmode = driver->universal_get_value<int8_t>(index + index_offset_, 0x0);
   if (hmode == 0)
   {
     return true;

--- a/canopen_402_driver/src/motor.cpp
+++ b/canopen_402_driver/src/motor.cpp
@@ -47,8 +47,8 @@ uint16_t Motor402::getMode()
 
 bool Motor402::isModeSupportedByDevice(uint16_t mode)
 {
-  uint32_t supported_modes =
-    driver->universal_get_value<uint32_t>(supported_drive_modes_index, 0x0);
+  uint32_t supported_modes = driver->universal_get_value<uint32_t>(
+    get_segmented_index(kSupportedDriveModesBaseIndex), 0x0);
   bool supported = supported_modes & (1 << (mode - 1));
   bool below_max = mode <= 32;
   bool above_min = mode > 0;
@@ -83,7 +83,7 @@ bool Motor402::switchMode(uint16_t mode)
     selected_mode_.reset();
     try
     {  // try to set mode
-      driver->universal_set_value<int8_t>(op_mode_index, 0x0, mode);
+      driver->universal_set_value<int8_t>(get_segmented_index(kOpModeBaseIndex), 0x0, mode);
     }
     catch (...)
     {
@@ -122,7 +122,7 @@ bool Motor402::switchMode(uint16_t mode)
 
   if (!switchState(switching_state_)) return false;
 
-  driver->universal_set_value<int8_t>(op_mode_index, 0x0, mode);
+  driver->universal_set_value<int8_t>(get_segmented_index(kOpModeBaseIndex), 0x0, mode);
 
   bool okay = false;
 
@@ -142,7 +142,7 @@ bool Motor402::switchMode(uint16_t mode)
       while (mode_id_ != mode && std::chrono::steady_clock::now() < abstime)
       {
         lock.unlock();                                                    // unlock inside loop
-        driver->universal_get_value<int8_t>(op_mode_display_index, 0x0);  // poll
+        driver->universal_get_value<int8_t>(get_segmented_index(kOpModeDisplayBaseIndex), 0x0);
         std::this_thread::sleep_for(std::chrono::milliseconds(20));       // wait some time
         lock.lock();
       }
@@ -160,7 +160,7 @@ bool Motor402::switchMode(uint16_t mode)
     else
     {
       RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Mode switch timed out.");
-      driver->universal_set_value<int8_t>(op_mode_index, 0x0, mode_id_);
+      driver->universal_set_value<int8_t>(get_segmented_index(kOpModeBaseIndex), 0x0, mode_id_);
       if (enable_diagnostics_.load())
       {
         this->diag_collector_->addf("cia402_mode", "Mode switch timed out: %d", mode);
@@ -211,14 +211,14 @@ bool Motor402::switchState(const State402::InternalState & target)
 bool Motor402::readState()
 {
   uint16_t old_sw, sw = driver->universal_get_value<uint16_t>(
-                     status_word_entry_index, 0x0);  // TODO: added error handling
+                     get_segmented_index(kStatusWordBaseIndex), 0x0);
   old_sw = status_word_.exchange(sw);
 
   state_handler_.read(sw);
 
   std::unique_lock lock(mode_mutex_);
   uint16_t new_mode;
-  new_mode = driver->universal_get_value<int8_t>(op_mode_display_index, 0x0);
+  new_mode = driver->universal_get_value<int8_t>(get_segmented_index(kOpModeDisplayBaseIndex), 0x0);
   // RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Mode %hhi",new_mode);
 
   if (selected_mode_ && selected_mode_->mode_id_ == new_mode)
@@ -278,13 +278,15 @@ void Motor402::handleWrite()
   {
     RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Fault reset");
     this->driver->universal_set_value<uint16_t>(
-      control_word_entry_index, 0x0, control_word_ & ~(1 << Command402::CW_Fault_Reset));
+      get_segmented_index(kControlWordBaseIndex), 0x0,
+      control_word_ & ~(1 << Command402::CW_Fault_Reset));
   }
   else
   {
     // RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Control Word %s",
     // std::bitset<16>{control_word_}.to_string());
-    this->driver->universal_set_value<uint16_t>(control_word_entry_index, 0x0, control_word_);
+    this->driver->universal_set_value<uint16_t>(
+      get_segmented_index(kControlWordBaseIndex), 0x0, control_word_);
   }
 }
 void Motor402::handleDiag()


### PR DESCRIPTION
## Summary
- allow the CiA 402 motor driver to shift all device profile indices by a configured CiA 301 segment
- propagate the segment offset through mode helpers, homing/profiled position modes, and motor state handling
- add a `device_profile_segment` configuration option and document how to use it

## Testing
- Not run (colcon not available in container)
